### PR TITLE
Fixed td-agent-bit failing with default conf

### DIFF
--- a/setup/log-forwarders/fluent-bit.md
+++ b/setup/log-forwarders/fluent-bit.md
@@ -37,10 +37,10 @@ description: Send logs to Timber via Fluent Bit
      Retry_Limit 5
   
    [FILTER]
-       Name record_modifier
-       # Will match all inputs, replace with your match if you want to send a subset
-       Match *
-       Record hostname ${HOSTNAME}
+     Name record_modifier
+     # Will match all inputs, replace with your match if you want to send a subset
+     Match *
+     Record hostname ${HOSTNAME}
    ```
    {% endcode-tabs-item %}
    {% endcode-tabs %}


### PR DESCRIPTION
If run it with default config - there is an error:
~$ /opt/td-agent-bit/bin/td-agent-bit -c //etc/td-agent-bit/td-agent-bit.conf
Fluent Bit v1.0.6
Copyright (C) Treasure Data

[2019/04/05 12:50:50] [  Error] File //etc/td-agent-bit/td-agent-bit.conf
[2019/04/05 12:50:50] [  Error] Error in line 19: Invalid indentation level