### PR TITLE
Fixed agent failing with default config

### DIFF
--- a/setup/log-forwarders/fluent-bit.md
+++ b/setup/log-forwarders/fluent-bit.md
@@ -19,6 +19,11 @@ description: Send logs to Timber via Fluent Bit
    {% code-tabs %}
    {% code-tabs-item title="/etc/td-agent-bit/td-agent-bit.conf" %}
    ```yaml
+   [INPUT]
+     # This is default input. You can replace it with your own or add some more
+     Name tail
+     Path /var/log/syslog
+     
    [SERVICE]
      # Reduce the flush interval for better real-time access
      Flush  2


### PR DESCRIPTION
If try run agent with default config provided here
~$ /opt/td-agent-bit/bin/td-agent-bit -c //etc/td-agent-bit/td-agent-bit.conf
Fluent Bit v1.0.6
Copyright (C) Treasure Data

Error: No Input(s) have been defined. Aborting