### PR TITLE
remove reference to Ecto integration

### DIFF
--- a/setup/languages/elixir/integrations/exceptions.md
+++ b/setup/languages/elixir/integrations/exceptions.md
@@ -4,10 +4,6 @@ description: Turn logged exceptions into structured exception events
 
 # Exceptions
 
-{% hint style="warning" %}
-The Timber Ecto integration requires [installation of the base `timber` Hex package](../#installation) first.
-{% endhint %}
-
 Timber integrates directly with Elixir to turn your exceptions into rich structured events. This reduces noise in your logs and makes them easier to search and use.
 
 ## Installation


### PR DESCRIPTION
This page is for the exceptions integration (not the Ecto integration as mentioned here)

The warnings is unnecessary as the mentioned package will be included automatically.

https://github.com/timberio/timber-elixir-exceptions/blob/master/mix.exs#L108