### PR TITLE
remove invalid request parameter "source_ids"

### DIFF
--- a/usage/filtering-logs.md
+++ b/usage/filtering-logs.md
@@ -35,7 +35,7 @@ curl https://api.timber.io/log_filters \
       "organization_id": "YOUR_ORGANIZATION_ID",
       "name":"FILTER_NAME",
       "match":"MATCH",
-      "source_ids": ["SOURCE_ID"]
+      "application_ids": ["SOURCE_ID"]
     }
   ' \
   | jq
@@ -71,7 +71,7 @@ curl https://api.timber.io/log_filters/ID \
   -s \
   -X PUT \
   -H "Authorization: Bearer YOUR_API_KEY" \
-  -d '{"source_ids": []}' \
+  -d '{"application_ids": []}' \
   | jq
 ```
 


### PR DESCRIPTION
It doesn't look like `source_ids` is the right name for that parameter. I'm not 100% certain that this is correct, since I haven't looked at the way this is actually implemented, but through experimentation this seems to be how it works.