### PR TITLE
update the timber fluentd docs to indicate that hostname is required

### DIFF
--- a/setup/log-forwarders/fluentd/README.md
+++ b/setup/log-forwarders/fluentd/README.md
@@ -32,6 +32,7 @@ If possible, we recommend using [Fluent Bit](../fluent-bit.md) for its superior 
      @type timber
      api_key YOUR_API_KEY
      source_id YOUR_SOURCE_ID
+     hostname YOUR_HOSTNAME
    </match>
    ```
    {% endcode-tabs-item %}


### PR DESCRIPTION
the fluent-plugin-timber readme says the hostname is mandatory, and my installation was failing without it which seems to support that claim