### PR TITLE
Fix typos in Elixir docs

### DIFF
--- a/setup/languages/elixir/integrations/phoenix/README.md
+++ b/setup/languages/elixir/integrations/phoenix/README.md
@@ -76,12 +76,12 @@ The `controller_called` event is emitted when a controller received a request.
 
 ### template\_rendered
 
-The `template_rendered` event is emitted when `ActionView` renders a template:
+The `template_rendered` event is emitted when `Phoenix.View` renders a template:
 
 ```javascript
 {
     "template_rendered": {
-        "name": "/path/to/template.html.erb",
+        "name": "/path/to/template.html.eex",
         "duration_ms": 50.4
     }
 }

--- a/setup/languages/elixir/integrations/plug.md
+++ b/setup/languages/elixir/integrations/plug.md
@@ -105,7 +105,7 @@ The `http_request_received` event is emitted when a HTTP request is received.
 | `http_request_received.request_id` | `string` | The request ID of the incoming HTTP request. |
 
 {% hint style="info" %}
-Where's the body? Timber purposefully leaves out the HTTP request body because it can be represented in many different formats. Instead, [we log the parameters in the `controller_called` event](phoenix/#controller_called) which will be in a normalized structured.
+Where's the body? Timber purposefully leaves out the HTTP request body because it can be represented in many different formats. Instead, [we log the parameters in the `controller_called` event](phoenix/#controller_called) which will be in a normalized structure.
 {% endhint %}
 
 ### http\_response\_sent


### PR DESCRIPTION
Fixes a couple minor typos, one of which is a Rails reference.